### PR TITLE
circle button. fix link to the top section

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
                     <div class="col-md-8 col-md-offset-2">
                         <img src="img/mm_logo.png" class="img-responsive" />
                         <p class="intro-text">Putting the World's Vulnerable People on the Map</p>
-                        <a href="#partners" class="btn btn-circle page-scroll">
+                        <a href="#about" class="btn btn-circle page-scroll">
                             <i class="fa fa-angle-double-down animated"></i>
                         </a>
                     </div>


### PR DESCRIPTION
we no longer have a #partners anchor name (commented out)  so the big "(v)" circle button is broken. The top section is now #about
