### PR TITLE
fixing a typo: cirses -> crises

### DIFF
--- a/mapathons/index.html
+++ b/mapathons/index.html
@@ -97,7 +97,7 @@
         <div class="row" style="padding-top:100px;">
             <div class="col-lg-10 col-lg-offset-1">
                 <h2>Host A Mapathon</h2>
-                <p>A mapathon is a unique and engaging opportunity for volunteers to digitally connect and map the most vulnerable places in the developing world so that local and international NGOs can use these comprehensive maps and data to better respond to cirses affecting these areas. Digital volunteer engagement is vital for the success of many humanitarian organizations around the world in responding to disasters. It is imperative to have a larger pool of trained volunteers that are ready to assist with little coordination when a disaster occurs. </p>
+                <p>A mapathon is a unique and engaging opportunity for volunteers to digitally connect and map the most vulnerable places in the developing world so that local and international NGOs can use these comprehensive maps and data to better respond to crises affecting these areas. Digital volunteer engagement is vital for the success of many humanitarian organizations around the world in responding to disasters. It is imperative to have a larger pool of trained volunteers that are ready to assist with little coordination when a disaster occurs. </p>
                 <div class="col-lg-8 col-lg-offset-2">
                    <div class="row">
                         <div class="col-sm-6 col-md-4 col-md-offset-2">


### PR DESCRIPTION
I fixed a typo on the Mapathons page