### PR TITLE
Adds in a logo file with the text not-outlined

### DIFF
--- a/app/assets/graphics/meta/MissingMapsLogo-Text.svg
+++ b/app/assets/graphics/meta/MissingMapsLogo-Text.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="795.1px" height="323.6px" viewBox="389 -152.6 795.1 323.6" style="enable-background:new 389 -152.6 795.1 323.6;"
+	 xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:#F17A22;}
+	.st2{fill:#F6EB00;}
+	.st3{fill:#E62825;}
+	.st4{fill:#9DC950;}
+	.st5{fill:#57C2F0;}
+	.st6{fill:#6E6F71;}
+	.st7{font-family:'Raleway-ExtraBold';}
+	.st8{font-size:126.3168px;}
+</style>
+<circle class="st0" cx="544" cy="9.9" r="155"/>
+<g>
+	<path class="st1" d="M680.5,3.6H575.1v-71.1h81.6C670.7-47.1,679.3-22.7,680.5,3.6z"/>
+	<path class="st2" d="M680.6,12.5c-0.5,26.1-8.3,50.5-21.5,71.1c-2,3.1-4,6-6.2,8.9c-3.4,4.5-7.2,8.8-11.1,12.9
+		c-2.8,2.9-5.8,5.7-8.9,8.4c-16.4,14-36.1,24.2-57.7,29.2c-2.9,0.7-5.9,1.3-8.9,1.8c-7.2,1.2-14.6,1.8-22.2,1.8
+		c-16.7,0-32.8-3-47.6-8.5V92.6h145.3v-80L680.6,12.5L680.6,12.5z"/>
+	<path class="st3" d="M632.8,12.5v71.1H428.9c-13.2-20.6-21-44.9-21.5-71.1H632.8z"/>
+	<path class="st4" d="M650-76.4H496.4v-41.8c14.8-5.5,30.9-8.5,47.6-8.5c7.5,0,15,0.6,22.2,1.8c3,0.5,6,1.1,8.9,1.8
+		c21.7,5,41.4,15.2,57.7,29.2c3.1,2.7,6.1,5.4,8.9,8.3C644.6-82.7,647.4-79.6,650-76.4z"/>
+	<g>
+		<path class="st5" d="M487.5-114.6V3.6h-80c1.2-26.3,9.8-50.7,23.9-71.1c2.1-3.1,4.3-6,6.7-8.9C451.3-92.6,468.2-105.8,487.5-114.6
+			z"/>
+	</g>
+</g>
+<text transform="matrix(1 0 0 1 723.9932 2.6129)"><tspan x="0" y="0" class="st6 st7 st8">Missing</tspan><tspan x="0" y="114" class="st6 st7 st8">Maps</tspan></text>
+</svg>


### PR DESCRIPTION
@dalekunce here you go!

I highly recommend using the outlined versions that are already in the repo for any use on the site itself.