### PR TITLE
Update URL of summary stats

### DIFF
--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -21,7 +21,7 @@ const priorStats = {
 };
 
 const xmlhttp = new XMLHttpRequest();
-const url = 'http://osmstats.redcross.org/';
+const url = 'http://osmstats.redcross.org/stats/missingmaps';
 
 xmlhttp.onreadystatechange = function () {
   if (xmlhttp.readyState === 4 && xmlhttp.status === 200) {


### PR DESCRIPTION
With osm-stats-api v0.4 we moved the summary statistics to the route `/stats/{hashtag}`. 
This commit updates the url for the front page statistics.

@dalekunce 