### PR TITLE
Discard Travis output

### DIFF
--- a/.build_scripts/deploy.sh
+++ b/.build_scripts/deploy.sh
@@ -10,7 +10,7 @@ if [ $TRAVIS_PULL_REQUEST = "false" ] && [ $TRAVIS_BRANCH = ${DEPLOY_BRANCH} ]; 
   git config user.email "travis@somewhere.com"
   git add .
   git commit -m "CI deploy to gh-pages"
-  git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" master:master
+  git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" master:master > /dev/null 2>&1
 else
   echo "Not a publishable branch so we're all done here"
 fi


### PR DESCRIPTION
@dalekunce devseedgit does not push to this repo. This discards the travis output however the bot token might need to be changed.