### PR TITLE
Fix some locale bugs

### DIFF
--- a/app/_data/es.yml
+++ b/app/_data/es.yml
@@ -32,7 +32,7 @@ nav:
       - text:     "TABLA DE LÍDERES" #######traduction pas top  ###
         url:      "http://www.missingmaps.org/leaderboards/"
       - text:     "OSMSTATS"
-        url:      "/osmstats/"
+        url:      "/es/osmstats/"
 
 #####################
 ## LANDING CONTENT ##

--- a/app/_data/fr.yml
+++ b/app/_data/fr.yml
@@ -32,7 +32,7 @@ nav:
       - text:     "PALMARES"
         url:      "http://www.missingmaps.org/leaderboards/"
       - text:     "OSMSTATS"
-        url:      "/osmstats/"
+        url:      "/fr/osmstats/"
 
 #####################
 ## LANDING CONTENT ##

--- a/app/en/osmstats.html
+++ b/app/en/osmstats.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 permalink: /osmstats/
-id: about
+id: osmstats
 lang: en
 ---
 {% include get_locale.html %}

--- a/app/es/osmstats.html
+++ b/app/es/osmstats.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 permalink: /es/osmstats/
-id: about
+id: osmstats
 lang: es
 ---
 {% include get_locale.html %}

--- a/app/fr/osmstats.html
+++ b/app/fr/osmstats.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 permalink: /fr/osmstats/
-id: about
+id: osmstats
 lang: fr
 ---
 {% include get_locale.html %}


### PR DESCRIPTION
This PR should fix part of #333:

> when on the 'osm stats' page using the language picker sends you to the 'about' page

This was caused by an incorrect ID of the OSMSTATS page. The ID was set to `about`.

After fixing this, I noticed that navigating to the OSMSTATS page in the fr or es locale directed the user to the English version of the page. I fixed those links as well.