### PR TITLE
replace tabletop with papapase

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Adding events
 
-Events are managed in the events.csv in the [events](https://github.com/MissingMaps/events) repo. Please update all new events there. Be sure to follow the instructions in the [Readme](https://github.com/MissingMaps/events/blob/master/README.md).
+Events are managed through a Google Form and Sheet.
 
 ### Adding Blog Post
 

--- a/app/_includes/events.html
+++ b/app/_includes/events.html
@@ -15,86 +15,120 @@ document.querySelector("header").style.display = 'inline-block';
 			</a>
 		</p>
 	</div>
-	<div class="row small-up-1 medium-up-1 large-up-2">
-	{% assign current_date = site.time | date: '%Y%m%d' %}
-	{% assign event = (site.data.events.events | sort: 'date' ) %}
-	{% for e in event %}
-	{% assign event_date = e.date | date: '%Y%m%d' %}
-	{% if event_date >= current_date %}
-	{% assign count = count | plus: 1 %}
-		<div class="column">
-		<div class="event-sub-container">
-			<div class="event-top-section clearfix">
-				<div class="sub-head">
-					<img class="event-images" src="{{ site.baseurl }}/assets/graphics/flags/4x3/{{ e.flag }}.svg" width="24px" />
-					<h3 class="event-header">{{ e.title }}</h3>
-					{% if e.signup_url %}
-					<a class="btn btn-grn" href="{{ e.signup_url }}" target="">{{site.data[locale].events.sign_up}}</a>
-					{% endif %}
-				</div>
-			</div>
-			<div class="event-maindetails clearfix">
-				<div class="event-details-left">
-					<span class="emphasizedNumber">
-						{{ e.date | localize: "%d",locale }}
-					</span>
-					<p><b>{{ e.date | localize: "%B",locale }}</b></p>
-				</div>
-				<div class="event-details-right">
-					<div class="textbox" style="padding-top:8px">
-						<p>
-							{% if e.place_url %}
-							<a href="{{ e.place_url }}"><b>{{ e.place_name }}</b></a> {% else %}
-							<b>{{ e.place_name }}</b>
-							{% endif %}
-						</p>
-						<p class="event-details">{{ e.date | localize: "%A",locale }}, {{ e.time_string }}</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+	<div id="eventList" class="row small-up-1 medium-up-1 large-up-2">
 
-	{% endif %}
-	{% endfor %}
 	</div>
-	<div id="map" class="event-sub-container" style="max-width:900px; height:475px;"></div>
+	<!-- <div id="map" class="event-sub-container" style="max-width:900px; height:475px;"></div> -->
 
 </div>
 
 <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
 <script src="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
+<script src="https://d3js.org/d3.v5.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/luxon@1.24.1/build/global/luxon.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/papaparse@5.2.0/papaparse.min.js"></script>
 <script>
 
-var h = (window.innerHeight > 500) ? 500 : window.innerHeight;
-var w = h * 1.5;
-var style = "height:" + h + "px; max-width:" + w + "px;"
-document.getElementById('map').setAttribute("style",style);
 
-var map = L.map('map', {
-	center: [0,0],
-	zoom: 2,
-	minZoom: 2,
-	scrollWheelZoom: false
-});
+var eventNameKey = "What is the name of your event?"
+var locationKey = "Where will your mapping party be held?"
+var placeUrlKey = "Please insert a link to your venue on openstreetmap.org"
+var signupKey = "Please insert a link where people can sign up"
+var dateKey = "Date? as YYYY-MM-DD"
+var startKey = "What time does your event start?"
+var endKey = "What time does your event end?"
+var countryKey = "Country?"
 
-L.tileLayer('http://api.tiles.mapbox.com/v4/mapbox.light/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoic3RhdGVvZnNhdGVsbGl0ZSIsImEiOiJlZTM5ODI5NGYwZWM2MjRlZmEyNzEyMWRjZWJlY2FhZiJ9.omsA8QDSKggbxiJjumiA_w.', {
-	attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-}).addTo(map);
+var today = luxon.DateTime.local().startOf('day');
+var siteBaseUrl = "{{ site.baseurl }}";	
+		
+/* USE TABLETOP TO GRAB EVENT DATA FROM GOOGLE SHEET */
+function init() {
+          Papa.parse('https://docs.google.com/spreadsheets/d/14MaSKvz7WmTS0mrj_hystgtQSgkDUvgVJruT4lnbY_U/pub?output=csv', {
+          download: true,
+          header: true,
+          complete: function(results) {
+						var data = results.data.filter(function(d){ 
+								return luxon.DateTime.fromISO(d[dateKey]).isValid 
+									&& luxon.DateTime.fromISO(d[dateKey]) >= today;
+						  }).sort(function(x, y){
+						   return d3.ascending(x[dateKey], y[dateKey]);
+							})
+            buildEvents(data)
+          }
+        })
+			}
+window.addEventListener('DOMContentLoaded', init)
 
-var markersGroup = L.featureGroup().addTo(map);
-
-{% for e in event %}
-if(isNaN(parseFloat("{{e.latitude}}")) === false && isNaN(parseFloat("{{e.longitude}}")) === false){
-	var myIcon = L.icon({
-		iconUrl: '/assets/graphics/content/blurred-marker.png',
-		iconSize:     [50, 50],
-		iconAnchor:   [25, 25]
-	});
-	L.marker([parseFloat("{{e.latitude}}"), parseFloat("{{e.longitude}}")],{icon: myIcon}).addTo(markersGroup);
+function buildEvents(data){
+	console.log(data)
+	d3.select('#eventList').selectAll('div').data(data)
+		.enter().append('div').classed('column', true)
+		.html(function(d){		
+			var countryIso = d[countryKey].substring(d[countryKey].indexOf("[")+1,d[countryKey].indexOf("]")).toLowerCase();
+			var signupHtml = (!!d[signupKey]) ? '<a class="btn btn-grn" href="' + d[signupKey] + '" target="">' + "{{site.data[locale].events.sign_up}}" + '</a>' : "";			
+			var placeHtml = (!!d[placeUrlKey])	? '<a href="' + d[placeUrlKey] + '"><b>' + d[locationKey] + '</b></a>' : '<b>' + d[locationKey] + '</b>';
+			
+			var eventHtml = '<div class="event-sub-container">' +
+					'<div class="event-top-section clearfix">' +
+						'<div class="sub-head">' +
+							'<img class="event-images" src="'+ siteBaseUrl + '/assets/graphics/flags/4x3/'+ countryIso +'.svg" width="24px" />' +
+							'<h3 class="event-header">' + d[eventNameKey] + '</h3>' +
+							signupHtml +
+						'</div>' +
+					'</div>' +
+					'<div class="event-maindetails clearfix">' +
+						'<div class="event-details-left">' +
+							'<span class="emphasizedNumber">' +
+								luxon.DateTime.fromISO(d[dateKey]).day +
+							'</span>' +
+							'<p><b>' + luxon.DateTime.fromISO(d[dateKey]).setLocale("{{locale}}").toLocaleString({ month: 'long'}) + '</b></p>' +
+						'</div>' +
+						'<div class="event-details-right">' +
+							'<div class="textbox" style="padding-top:8px">' +
+								'<p>' +
+									placeHtml +
+								'</p>' +
+								'<p class="event-details">' + luxon.DateTime.fromISO(d[dateKey]).setLocale("{{locale}}").toLocaleString({ weekday: 'long'}) + ", " + d[startKey] + " - " + d[endKey]  + '</p>' +
+							'</div>' +
+						'</div>' +
+					'</div>' +
+				'</div>';
+			return eventHtml;
+	})
+	
 }
-{% endfor %}
 
-map.fitBounds(markersGroup.getBounds());
+
+// var h = (window.innerHeight > 500) ? 500 : window.innerHeight;
+// var w = h * 1.5;
+// var style = "height:" + h + "px; max-width:" + w + "px;"
+// document.getElementById('map').setAttribute("style",style);
+// 
+// var map = L.map('map', {
+// 	center: [0,0],
+// 	zoom: 2,
+// 	minZoom: 2,
+// 	scrollWheelZoom: false
+// });
+// 
+// L.tileLayer('http://api.tiles.mapbox.com/v4/mapbox.light/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoic3RhdGVvZnNhdGVsbGl0ZSIsImEiOiJlZTM5ODI5NGYwZWM2MjRlZmEyNzEyMWRjZWJlY2FhZiJ9.omsA8QDSKggbxiJjumiA_w.', {
+// 	attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+// }).addTo(map);
+// 
+// var markersGroup = L.featureGroup().addTo(map);
+// 
+// {% for e in event %}
+// if(isNaN(parseFloat("{{e.latitude}}")) === false && isNaN(parseFloat("{{e.longitude}}")) === false){
+// 	var myIcon = L.icon({
+// 		iconUrl: '/assets/graphics/content/blurred-marker.png',
+// 		iconSize:     [50, 50],
+// 		iconAnchor:   [25, 25]
+// 	});
+// 	L.marker([parseFloat("{{e.latitude}}"), parseFloat("{{e.longitude}}")],{icon: myIcon}).addTo(markersGroup);
+// }
+// {% endfor %}
+// 
+// map.fitBounds(markersGroup.getBounds());
 
 </script>

--- a/app/_includes/events.html
+++ b/app/_includes/events.html
@@ -42,7 +42,7 @@ var countryKey = "Country?"
 var today = luxon.DateTime.local().startOf('day');
 var siteBaseUrl = "{{ site.baseurl }}";	
 		
-/* USE TABLETOP TO GRAB EVENT DATA FROM GOOGLE SHEET */
+/* USE PAPAPARSE TO GRAB EVENT DATA FROM GOOGLE SHEET */
 function init() {
           Papa.parse('https://docs.google.com/spreadsheets/d/14MaSKvz7WmTS0mrj_hystgtQSgkDUvgVJruT4lnbY_U/pub?output=csv', {
           download: true,

--- a/app/_includes/helper-map.html
+++ b/app/_includes/helper-map.html
@@ -56,7 +56,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/what-input/4.0.6/what-input.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.3.0/js/foundation.min.js"></script>
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/tabletop.js/1.5.1/tabletop.min.js'></script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.2.0/papaparse.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.6.0/d3.min.js"></script>
     <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
     <!-- <script src="https://use.fontawesome.com/eb154e6e77.js"></script> -->
@@ -281,11 +281,15 @@
 
 
   // get the contact data from the google spreadhsheet
-  var publicSpreadsheetUrl = 'https://docs.google.com/spreadsheets/d/1eWf7ZrUmzqNOBmv-mNdZqssFPwDyvNLQzxFXEGaMgB4/pubhtml?gid=1040223163&single=true';
+  var publicSpreadsheetUrl = 'https://docs.google.com/spreadsheets/d/1eWf7ZrUmzqNOBmv-mNdZqssFPwDyvNLQzxFXEGaMgB4/pub?output=csv';
   function init() {
-    Tabletop.init( { key: publicSpreadsheetUrl,
-                     callback: showInfo,
-                     simpleSheet: true } )
+    Papa.parse(publicSpreadsheetUrl, {
+   		download: true,
+   		header: true,
+   		complete: function(results) {
+   			showInfo(results.data);
+   		}
+   	});         
   }
 
   // column headers from Google sheet holding contact data
@@ -304,7 +308,7 @@
     return 'help_' + value.replace(/\s/g,'').toLowerCase();
   }
 
-  function showInfo(data, tabletop) {
+  function showInfo(data) {
     validMarkers = [];
     allLanguages = [];
     // add a LatLng object and an ID to each item in the dataset

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -1,6 +1,8 @@
+{% comment %}Getting the locale from the url{% endcomment %}{% capture locale %}{{ page.url | truncate: 3, "" | remove: "/" }}{% endcapture %}{% unless site.authorized_locales contains locale %}{% assign locale = site.default_locale %}{% endunless %}
+
 <!DOCTYPE html>
-<!--[if lt IE 10]> <html class="lt-ie10 no-js"  lang=""> <![endif]-->
-<!--[if gt IE 9]><!--> <html class="no-js" lang=""> <!--<![endif]-->
+<!--[if lt IE 10]> <html class="lt-ie10 no-js"  lang="{{locale}}"> <![endif]-->
+<!--[if gt IE 9]><!--> <html class="no-js" lang="{{locale}}"> <!--<![endif]-->
 
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
> Now that it's 2020, Google is shutting down the infrastructure that Tabletop relies on.

via https://github.com/jsoma/tabletop, they recommend switching to [PapaParse](https://www.papaparse.com/)


this also changes the events page to feed from a Google Sheet instead of the events.csv repository