### PR TITLE
add mm projects map gif to landing page, add iframe to osm stats page

### DIFF
--- a/app/_includes/landing.html
+++ b/app/_includes/landing.html
@@ -148,6 +148,9 @@
       <div class="title section-header">{{site.data[locale].contributions.title}}</div>
     </div>
     <div class="row">
+      <img src="../assets/graphics/content/missing_maps_projects_small.gif" width="500px">
+    </div>
+    <div class="row">
       <div class="Discover-Stats">
         <div class="sub-head Discover-Title">
           {{site.data[locale].contributions.subtitle}}

--- a/app/_includes/statistics.html
+++ b/app/_includes/statistics.html
@@ -10,34 +10,8 @@ document.querySelector("header").style.display = 'inline-block';
 	</div>
 	<div class="row">
 		<div class="large-11 large-centered columns">
-			<div class='tableauPlaceholder' id='viz1522710248219' style='height: 1069px;'>
-				<noscript>
-					<a href='#'><img alt='Dashboard 1 ' src='https:&#47;&#47;public.tableau.com&#47;static&#47;images&#47;OS&#47;OSMStats_0&#47;Dashboard1&#47;1_rss.png' style='border: none' /></a>
-				</noscript>
-				<object class='tableauViz' width='100%' height='1069' style='display:none;'>
-					<param name='host_url' value='https%3A%2F%2Fpublic.tableau.com%2F' />
-					<param name='embed_code_version' value='3' />
-					<param name='site_root' value='' />
-					<param name='name' value='OSMStats_0&#47;Dashboard1' />
-					<param name='tabs' value='no' />
-					<param name='toolbar' value='yes' />
-					<param name='static_image' value='https:&#47;&#47;public.tableau.com&#47;static&#47;images&#47;OS&#47;OSMStats_0&#47;Dashboard1&#47;1.png' />
-					<param name='animate_transition' value='yes' />
-					<param name='display_static_image' value='yes' />
-					<param name='display_spinner' value='yes' />
-					<param name='display_overlay' value='yes' />
-					<param name='display_count' value='yes' />
-					<param name='filter' value='publish=yes' />
-				</object>
-			</div>
-			<script type='text/javascript'>
-				var divElement = document.getElementById('viz1522710248219');
-				var vizElement = divElement.getElementsByTagName('object')[0];
-				vizElement.style.width='1000px';vizElement.style.height='1027px';
-				var scriptElement = document.createElement('script');
-				scriptElement.src = 'https://public.tableau.com/javascripts/api/viz_v1.js';
-				vizElement.parentNode.insertBefore(scriptElement, vizElement);
-			</script>
+			<!-- setting height to 1600px here so that there is no need to scroll within the iframe -->
+			<iframe src="https://humstats.heigit.org/missing_maps.html" title="Humanitarian OSM Stats" width="100%" height="1600px"></iframe>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Hey @rachblevine @danbjoseph,
this PR adds a gif to the landing page which shows a map of all missing maps projects and how much mapping has been done.

We might need to add a caption to the gif. But let's do this once we know it works.

Furthermore, the stats page is adjusted. Previously Tableau has been embedded to show OSM statistics. This has bee replaced with a simple iframe to point to a page at https://humstats.heigit.org/. (The actual page https://humstats.heigit.org/missing_maps.html will be set up in the next few days.)

I could not test these changes locally, since I was not able to set up and install gulp properly. I hope that these small changes could be tested on the missing maps page side then.
