### PR TITLE
Fixing issue with the link to Advanced JOSM pdf

### DIFF
--- a/app/_includes/advanced.html
+++ b/app/_includes/advanced.html
@@ -11,9 +11,9 @@
   
   <div class="row contribute-options">
     <div class="columns" style="text-align: center">
-      <a href="{{ site.baseurl }}/assets/downloads/{{site.data[locale].checker.links.advancedJOSM_pdf}}">
+      <a href="{{ site.baseurl }}/assets/downloads/{{site.data[locale].advanced.links.advancedJOSM_pdf}}">
         <img src="{{ site.baseurl }}/assets/graphics/content/process/Learn-MapNow.svg" alt="{{site.data[locale].img-alt.Learn-MapNow}}" /><br>
-        <div class="btn btn-grn contribute-caps">{{site.data[locale].checker.links.guide}}</div>
+        <div class="btn btn-grn contribute-caps">{{site.data[locale].advanced.links.guide}}</div>
       </a>
     </div>
   </div>


### PR DESCRIPTION
Currently showing a 404 when opening the link on the website - both FR and EN. These changes should fix the issue