### PR TITLE
Switchover to ohsome: remove leaderboards users pages links

### DIFF
--- a/app/_data/cs.yml
+++ b/app/_data/cs.yml
@@ -78,8 +78,8 @@ nav:
     url:          "/cs/blog/"
   - text:         "PROZKOUMAT"
     links:
-      - text:     "STATISTIKY"
-        url:      "/cs/statistiky/"
+      - text:     "STATISTIKY <svg width='9' height='9' viewBox='0 0 11 11' title='externalLink' style='height: 9px;'><path fill='currentColor' d='M9.778 9.778H1.222V1.222H5.5V0H1.222C.544 0 0 .55 0 1.222v8.556C0 10.45.544 11 1.222 11h8.556C10.45 11 11 10.45 11 9.778V5.5H9.778v4.278zM6.722 0v1.222h2.194L2.91 7.23l.862.862 6.007-6.007v2.194H11V0H6.722z'></path></svg>"
+        url:      "https://stats.now.ohsome.org/"
 
 #####################
 ## LANDING CONTENT ##

--- a/app/_data/cs.yml
+++ b/app/_data/cs.yml
@@ -146,16 +146,6 @@ contributions:
   buildings:    "budov"
   roads:        "km silnic"
 
-discover:
-  title:        "Objevte více"
-  subtitle:     "Pro sledování vlastních a projektových příspěvků nabízí Missing Maps dva nástroje. "
-  profiles:     "Profily uživatelů"
-  profile_text: "Zkontrolujte své příspěvky v HOT úlohách!"
-  profile_btn:  "VYHLEDAT UŽIVATELE"
-  projects:     "Žebříčky projektu"
-  project_text: "Zjistěte, jak si vedete v porovnání s ostatními!"
-  project_btn:  "NAJÍT ŽEBŘÍČEK"
-
 contact:
   title:        "Kontaktujte nás"
 

--- a/app/_data/en.yml
+++ b/app/_data/en.yml
@@ -78,8 +78,8 @@ nav:
     url:          "/blog/"
   - text:         "EXPLORE"
     links:
-      - text:     "STATISTICS"
-        url:      "/statistics/"
+      - text:     "STATISTICS <svg width='9' height='9' viewBox='0 0 11 11' title='externalLink' style='height: 9px;'><path fill='currentColor' d='M9.778 9.778H1.222V1.222H5.5V0H1.222C.544 0 0 .55 0 1.222v8.556C0 10.45.544 11 1.222 11h8.556C10.45 11 11 10.45 11 9.778V5.5H9.778v4.278zM6.722 0v1.222h2.194L2.91 7.23l.862.862 6.007-6.007v2.194H11V0H6.722z'></path></svg>"
+        url:      "https://stats.now.ohsome.org/"
 
 #####################
 ## LANDING CONTENT ##

--- a/app/_data/en.yml
+++ b/app/_data/en.yml
@@ -147,16 +147,6 @@ contributions:
   buildings:    "Building Edits"
   roads:        "Roads (km)"
 
-discover:
-  title:        "Discover"
-  subtitle:     "To track your individual & project contributions Missing Maps provides two tools."
-  profiles:     "User Profiles"
-  profile_text: "Check out your contributions to HOT tasks!"
-  profile_btn:  "FIND A USER"
-  projects:     "Project Leaderboards"
-  project_text: "Find out where you stand among contributed hashtags!"
-  project_btn:  "FIND A LEADERBOARD"
-
 contact:
   title:        "Contact Us"
 

--- a/app/_data/es.yml
+++ b/app/_data/es.yml
@@ -146,17 +146,6 @@ contributions:
   edits:        "Ediciones"
   buildings:    "Edición de edificios"
   roads:        "Carreteras (km)"
-
-discover:
-  title:        "Descubrir"
-  subtitle:     "Para seguir tus contribuciones individuales y de proyecto, Missing Maps proporciona dos herramientas."
-  profiles:     "Perfiles de usuarios"
-  profile_text: "Revisa tus contribuciones en las tareas del HOT!"
-  profile_btn:  "BUSCAR UN CONTRIBUIDOR"
-  projects:     "Tabla de líderes de proyectos"
-  project_text: "Averigua su clasificación de contribuciones!"
-  project_btn:  "IR A TABLA DE LÍDERES"
-
 contact:
   title:        "Contacta con nosotros"
 

--- a/app/_data/es.yml
+++ b/app/_data/es.yml
@@ -78,8 +78,8 @@ nav:
     url:          "/es/blog/"
   - text:         "EXPLORAR"
     links:
-      - text:     "ESTADÍSTICAS"
-        url:      "/es/statistics/"
+      - text:     "ESTADÍSTICAS <svg width='9' height='9' viewBox='0 0 11 11' title='externalLink' style='height: 9px;'><path fill='currentColor' d='M9.778 9.778H1.222V1.222H5.5V0H1.222C.544 0 0 .55 0 1.222v8.556C0 10.45.544 11 1.222 11h8.556C10.45 11 11 10.45 11 9.778V5.5H9.778v4.278zM6.722 0v1.222h2.194L2.91 7.23l.862.862 6.007-6.007v2.194H11V0H6.722z'></path></svg>"
+        url:      "https://stats.now.ohsome.org/"
 
 #####################
 ## LANDING CONTENT ##

--- a/app/_data/fr.yml
+++ b/app/_data/fr.yml
@@ -144,16 +144,6 @@ contributions:
   buildings:    "Modifications de bâtiments"
   roads:        "Routes (km)"
 
-discover:
-  title:        "Découvrir"
-  subtitle:     "Pour suivre vos contributions individuelles et par projet, Missing Maps fournit deux outils."
-  profiles:     "Profils des Contributeurs"
-  profile_text: "Vérifiez vos contributions sur les tâches de HOT !"
-  profile_btn:  "TROUVER UN CONTRIBUTEUR"
-  projects:     "Tableau des meneurs des projets"
-  project_text: "Découvrez où vous en êtes parmi d'autres !"
-  project_btn:  "ALLER AU TABLEAU DES MENEURS"
-
 contact:
   title:        "Contactez-nous"
 

--- a/app/_data/fr.yml
+++ b/app/_data/fr.yml
@@ -78,8 +78,8 @@ nav:
     url:          "/fr/blog/"
   - text:         "EXPLORER"
     links:
-      - text:     "STATISTIQUES"
-        url:      "/fr/statistiques/"
+      - text:     "STATISTIQUES <svg width='9' height='9' viewBox='0 0 11 11' title='externalLink' style='height: 9px;'><path fill='currentColor' d='M9.778 9.778H1.222V1.222H5.5V0H1.222C.544 0 0 .55 0 1.222v8.556C0 10.45.544 11 1.222 11h8.556C10.45 11 11 10.45 11 9.778V5.5H9.778v4.278zM6.722 0v1.222h2.194L2.91 7.23l.862.862 6.007-6.007v2.194H11V0H6.722z'></path></svg>"
+        url:      "https://stats.now.ohsome.org/"
 
 #####################
 ## LANDING CONTENT ##

--- a/app/_includes/landing.html
+++ b/app/_includes/landing.html
@@ -200,28 +200,6 @@
     </div>
   </div>
 </div>
-<div class="row Discover-Tools">
-  <div class="title section-header">{{site.data[locale].discover.title}}</div>
-  <div class="sub-head Discover-Sub">
-    {{site.data[locale].discover.subtitle}}
-  </div>
-  <div class="osmanalytic-item-container medium-6 columns">
-    <img src="../assets/graphics/content/process/ProfileGraphic.svg" width="200px" alt="{{site.data[locale].img-alt.ProfileGraphic}}" />
-    <div class="title">{{site.data[locale].discover.profiles}}</div>
-    <div class="textbox">
-      <p style="text-align: center">{{site.data[locale].discover.profile_text}}</p>
-    </div>
-    <div class="btn btn-blue"><a href="http://www.missingmaps.org/users/">{{site.data[locale].discover.profile_btn}}</a></div>
-  </div>
-  <div class="osmanalytic-item-container medium-6 columns">
-    <img src="{{ site.baseurl }}/assets/graphics/content/process/LeaderboardGraphic.svg" width="200px" alt="{{site.data[locale].img-alt.LeaderboardGraphic}}" />
-    <div class="title">{{site.data[locale].discover.projects}}</div>
-    <div class="textbox">
-      <p style="text-align: center">{{site.data[locale].discover.project_text}}</p>
-    </div>
-    <div class="btn btn-blue"><a href="http://www.missingmaps.org/leaderboards/">{{site.data[locale].discover.project_btn}}</a></div>
-  </div>
-</div>
 
 <!-- ~ ~ ~ ~ ~ ~ ~ ~ ~  -->
 <!-- Events -->


### PR DESCRIPTION
With the new [ohsome](https://stats.now.ohsome.org/dashboard) stats site, the leaderboards and user profile pages are going to become irrelevant, or will be handled by other tools such as the Tasking Manager user profile page. This PR changes the links over to ohsome and removes references to the defunct parts of the missing maps site. 